### PR TITLE
fix: put token files somewhere standard

### DIFF
--- a/playerdatapy/auth/authorisation_code_flow.py
+++ b/playerdatapy/auth/authorisation_code_flow.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import Optional, Union
+
 from .authorisation_code_flow_base import AuthorisationCodeFlowBase
 
 
@@ -5,7 +8,11 @@ class AuthorisationCodeFlow(AuthorisationCodeFlowBase):
     """Handles oauth2 authorisation code flow and token management."""
 
     def __init__(
-        self, client_id: str, port: int, client_secret: str, token_file: str = ".token"
+        self,
+        client_id: str,
+        port: int,
+        client_secret: str,
+        token_file: Optional[Union[str, Path]] = None,
     ):
         super().__init__(client_id, port, token_file)
         self.client_secret = client_secret

--- a/playerdatapy/auth/authorisation_code_flow_base.py
+++ b/playerdatapy/auth/authorisation_code_flow_base.py
@@ -1,4 +1,6 @@
 import webbrowser
+from pathlib import Path
+from typing import Optional, Union
 from requests_oauthlib import OAuth2Session
 
 from .base_flow import BaseAuthFlow
@@ -8,7 +10,9 @@ from .server import Server
 class AuthorisationCodeFlowBase(BaseAuthFlow):
     """Base class for OAuth2 authorization code flows with token management."""
 
-    def __init__(self, client_id: str, port: int, token_file: str = ".token"):
+    def __init__(
+        self, client_id: str, port: int, token_file: Optional[Union[str, Path]] = None
+    ):
         super().__init__(client_id, token_file)
         self.server = Server(port)
 

--- a/playerdatapy/auth/base_flow.py
+++ b/playerdatapy/auth/base_flow.py
@@ -1,38 +1,39 @@
-import os
 import json
 import time
+from pathlib import Path
+from typing import Optional, Union
 from oauthlib.oauth2 import TokenExpiredError
 from playerdatapy.constants import API_BASE_URL
+from .token_storage import default_token_path
 
 
 class BaseAuthFlow:
     """Base class for OAuth2 authentication flows with token management."""
 
-    def __init__(self, client_id: str, token_file: str = ".token"):
+    def __init__(self, client_id: str, token_file: Optional[Union[str, Path]] = None):
         self.client_id = client_id
-        self.token_file = token_file
+        self.token_file: Path = Path(token_file) if token_file else default_token_path()
         self.api_base_url = API_BASE_URL
         self.oauth_session = None
 
     def get_token(self) -> dict:
         """Load token from file and check if it's expired."""
-        if not os.path.exists(self.token_file):
+        if not self.token_file.exists():
             raise TokenExpiredError("No token file found")
 
-        with open(self.token_file, "r") as f:
-            tokens = f.read()
-            if not tokens:
-                raise TokenExpiredError("Token file is empty")
-            token = json.loads(tokens)
+        tokens = self.token_file.read_text()
+        if not tokens:
+            raise TokenExpiredError("Token file is empty")
+        token = json.loads(tokens)
 
-            if "expires_at" in token:
-                current_time = time.time()
-                if token["expires_at"] <= current_time:
-                    raise TokenExpiredError("Token has expired")
+        if "expires_at" in token:
+            current_time = time.time()
+            if token["expires_at"] <= current_time:
+                raise TokenExpiredError("Token has expired")
 
-            return token
+        return token
 
     def save_token(self, token: dict):
         """Save token to file."""
-        with open(self.token_file, "w") as f:
-            f.write(json.dumps(token))
+        self.token_file.parent.mkdir(parents=True, exist_ok=True)
+        self.token_file.write_text(json.dumps(token))

--- a/playerdatapy/auth/client_credentials_flow.py
+++ b/playerdatapy/auth/client_credentials_flow.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+from typing import Optional, Union
 from requests_oauthlib import OAuth2Session
 from oauthlib.oauth2 import BackendApplicationClient
 
@@ -7,7 +9,12 @@ from .base_flow import BaseAuthFlow
 class ClientCredentialsFlow(BaseAuthFlow):
     """Handles oauth2 client credentials flow and token management."""
 
-    def __init__(self, client_id: str, client_secret: str, token_file: str = ".token"):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        token_file: Optional[Union[str, Path]] = None,
+    ):
         super().__init__(client_id, token_file)
         self.client_secret = client_secret
 

--- a/playerdatapy/auth/token_storage.py
+++ b/playerdatapy/auth/token_storage.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+_APP_NAME = "playerdatapy"
+_TOKEN_FILENAME = "token.json"
+
+
+def user_data_dir() -> Path:
+    """Return the per-user data directory for this app, following OS conventions."""
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~\\AppData\\Local")
+    elif sys.platform == "darwin":
+        base = os.path.expanduser("~/Library/Application Support")
+    else:
+        base = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
+    return Path(base) / _APP_NAME
+
+
+def default_token_path() -> Path:
+    """Return the default cross-platform path for the persisted OAuth token."""
+    return user_data_dir() / _TOKEN_FILENAME

--- a/playerdatapy/gqlauth.py
+++ b/playerdatapy/gqlauth.py
@@ -3,12 +3,15 @@ GraphQL client for the Playerdata API
 """
 
 from enum import Enum
+from pathlib import Path
+from typing import Optional, Union
 from requests_oauthlib import OAuth2Session  # type: ignore[import-untyped]
 from oauthlib.oauth2 import TokenExpiredError  # type: ignore[import-untyped]
 
 from playerdatapy.auth.authorisation_code_flow import AuthorisationCodeFlow
 from playerdatapy.auth.authorisation_code_flow_pcke import AuthorisationCodeFlowPCKE
 from playerdatapy.auth.client_credentials_flow import ClientCredentialsFlow
+from playerdatapy.auth.token_storage import default_token_path
 from playerdatapy.constants import API_BASE_URL
 
 
@@ -26,14 +29,14 @@ class GraphqlAuth:
     def __init__(
         self,
         client_id: str,
-        token_file: str = ".token",
+        token_file: Optional[Union[str, Path]] = None,
         client_secret: str = "",
         redirect_uri: str = "http://localhost:8888",
         port: int = 8888,
         type: AuthenticationType = AuthenticationType.AUTHORISATION_CODE_FLOW,
     ):
         self.client_id = client_id
-        self.token_file = token_file
+        self.token_file: Path = Path(token_file) if token_file else default_token_path()
         self.authenticator = None
         self.authentication_type = type
         self.client_secret = client_secret

--- a/playerdatapy/playerdata_api.py
+++ b/playerdatapy/playerdata_api.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import Optional, Union
+
 from .gqlauth import GraphqlAuth, AuthenticationType
 from .gqlclient import Client
 from .base_operation import GraphQLField
@@ -10,7 +13,7 @@ class PlayerDataAPI(GraphqlAuth):
         client_id: str,
         client_secret: str = "",
         redirect_uri: str = "http://localhost:8888",
-        token_file: str = ".token",
+        token_file: Optional[Union[str, Path]] = None,
         port: int = 8888,
         authentication_type: AuthenticationType = AuthenticationType.AUTHORISATION_CODE_FLOW,
     ):

--- a/tests/auth/test_authorisation_code_flow.py
+++ b/tests/auth/test_authorisation_code_flow.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
@@ -24,7 +25,7 @@ class TestAuthorisationCodeFlow:
 
             assert flow.client_id == "test_client"
             assert flow.client_secret == "test_secret"
-            assert flow.token_file == ".test_token"
+            assert flow.token_file == Path(".test_token")
             assert flow.server == mock_server
 
     def test_fetch_token_with_client_secret(self):

--- a/tests/auth/test_authorisation_code_flow_base.py
+++ b/tests/auth/test_authorisation_code_flow_base.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
+from pathlib import Path
 import pytest
 
 from playerdatapy.auth.authorisation_code_flow_base import AuthorisationCodeFlowBase
@@ -24,7 +25,7 @@ class TestAuthorisationCodeFlowBase:
             )
 
             assert flow.client_id == "test_client"
-            assert flow.token_file == ".test_token"
+            assert flow.token_file == Path(".test_token")
             assert flow.server == mock_server
             mock_server_class.assert_called_once_with(8080)
 

--- a/tests/auth/test_authorisation_code_flow_pcke.py
+++ b/tests/auth/test_authorisation_code_flow_pcke.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
@@ -20,7 +21,7 @@ class TestAuthorisationCodeFlowPCKE:
             )
 
             assert flow.client_id == "test_client"
-            assert flow.token_file == ".test_token"
+            assert flow.token_file == Path(".test_token")
             assert flow.server == mock_server
             # Should not have client_secret attribute
             assert not hasattr(flow, "client_secret")

--- a/tests/auth/test_base_flow.py
+++ b/tests/auth/test_base_flow.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import time
 
+from pathlib import Path
 import pytest
 from oauthlib.oauth2 import TokenExpiredError
 
@@ -19,7 +20,7 @@ class TestBaseAuthFlow:
         flow = BaseAuthFlow(client_id="test_client", token_file=".test_token")
         assert flow.client_id == "test_client"
         assert flow.api_base_url == API_BASE_URL
-        assert flow.token_file == ".test_token"
+        assert flow.token_file == Path(".test_token")
         assert flow.oauth_session is None
 
     def test_save_token(self):

--- a/tests/auth/test_client_credentials_flow.py
+++ b/tests/auth/test_client_credentials_flow.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
+from pathlib import Path
 import pytest
 
 from playerdatapy.auth.client_credentials_flow import ClientCredentialsFlow
@@ -20,7 +21,7 @@ class TestClientCredentialsFlow:
         )
         assert flow.client_id == "test_client"
         assert flow.client_secret == "test_secret"
-        assert flow.token_file == ".test_token"
+        assert flow.token_file == Path(".test_token")
         assert flow.oauth_session is None
 
     @patch("playerdatapy.auth.client_credentials_flow.OAuth2Session")

--- a/tests/test_gqlauth.py
+++ b/tests/test_gqlauth.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from oauthlib.oauth2 import TokenExpiredError  # type: ignore[import-untyped]
 
+from playerdatapy.auth.token_storage import default_token_path
 from playerdatapy.gqlauth import GraphqlAuth, AuthenticationType
 
 
@@ -29,12 +31,14 @@ class TestGraphqlAuth:
 
         assert auth.client_id == "test_client"
         assert auth.client_secret == "test_secret"
-        assert auth.token_file == ".token"
+        assert auth.token_file == default_token_path()
         assert auth.redirect_uri == "http://localhost:8888"
         assert auth.port == 8888
         assert auth.authentication_type == AuthenticationType.CLIENT_CREDENTIALS_FLOW
         assert auth.authenticator == mock_authenticator
-        mock_flow_class.assert_called_once_with("test_client", "test_secret", ".token")
+        mock_flow_class.assert_called_once_with(
+            "test_client", "test_secret", default_token_path()
+        )
 
     @patch("playerdatapy.gqlauth.OAuth2Session")
     @patch("playerdatapy.gqlauth.AuthorisationCodeFlow")
@@ -59,12 +63,12 @@ class TestGraphqlAuth:
 
         assert auth.client_id == "test_client"
         assert auth.client_secret == "test_secret"
-        assert auth.token_file == ".test_token"
+        assert auth.token_file == Path(".test_token")
         assert auth.redirect_uri == "http://localhost:9999"
         assert auth.port == 9999
         assert auth.authentication_type == AuthenticationType.AUTHORISATION_CODE_FLOW
         mock_flow_class.assert_called_once_with(
-            "test_client", 9999, "test_secret", ".test_token"
+            "test_client", 9999, "test_secret", Path(".test_token")
         )
 
     @patch("playerdatapy.gqlauth.OAuth2Session")
@@ -91,7 +95,9 @@ class TestGraphqlAuth:
         assert (
             auth.authentication_type == AuthenticationType.AUTHORISATION_CODE_FLOW_PCKE
         )
-        mock_flow_class.assert_called_once_with("test_client", 8888, ".test_token")
+        mock_flow_class.assert_called_once_with(
+            "test_client", 8888, Path(".test_token")
+        )
 
     @patch("playerdatapy.gqlauth.OAuth2Session")
     @patch("playerdatapy.gqlauth.ClientCredentialsFlow")

--- a/tests/test_playerdata_api.py
+++ b/tests/test_playerdata_api.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from playerdatapy.auth.token_storage import default_token_path
 from playerdatapy.playerdata_api import PlayerDataAPI
 from playerdatapy.gqlauth import AuthenticationType
 from playerdatapy.base_operation import GraphQLField
@@ -68,7 +69,7 @@ class TestPlayerdataAPI:
         assert interface.client_id == "test_client"
         assert interface.client_secret == ""
         assert interface.redirect_uri == "http://localhost:8888"
-        assert interface.token_file == ".token"
+        assert interface.token_file == default_token_path()
         assert interface.port == 8888
         assert (
             interface.authentication_type == AuthenticationType.AUTHORISATION_CODE_FLOW


### PR DESCRIPTION
It'll stop us having to re auth every time we invoke playerdatapy from a different directory. 