### PR TITLE
ci: stop dependency bumps retriggering docs/codegen and fix gh-pages deploy race

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -11,7 +11,6 @@ on:
     branches: [main]
     paths:
       - "schema.graphql"
-      - ".github/workflows/codegen.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,11 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "playerdatapy/**"
-      - ".github/workflows/docs.yml"
   workflow_dispatch:
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Prevents redundant docs and codegen workflow reruns triggered by Renovate action-version bumps that edit the workflow files themselves. Also serializes docs deploys to fix a `gh-pages (fetch first)` non-fast-forward push race that intermittently failed docs runs.

## Changes

- Remove `.github/workflows/docs.yml` from the docs push path filter so workflow-only bumps no longer retrigger the docs deploy on merge to main
- Remove `.github/workflows/codegen.yml` from the codegen push path filter for the same retrigger fix
- Add a `docs-deploy` concurrency group with `cancel-in-progress: false` to serialize deploys and avoid the gh-pages push race

## Testing

- Ran lint and the existing test suite; both pass
- Changes are YAML workflow-only edits, so no new unit tests apply