### PR TITLE
chore: assign data-analysis team as renovate reviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>PlayerData/renovate-config"
+  ],
+  "reviewers": [
+    "team:data-analysis"
   ]
 }


### PR DESCRIPTION
## Summary

Configures Renovate to request review from the data-analysis team on every dependency PR it opens. This ensures the right people are automatically looped in on dependency updates without manual assignment.

## Changes

- Add `reviewers: ["team:data-analysis"]` to `renovate.json`

## Testing

Config-only change. Renovate config linting passed; no unit tests apply.