### PR TITLE
feat: allow overriding API base URL per client

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -129,6 +129,28 @@ SDK opens a browser, captures the redirect, exchanges code → token, stores it.
      -d "client_id=$CLIENT_ID"
    ```
 
+## Pointing at a different environment
+
+By default the SDK talks to production (`https://app.playerdata.co.uk`). To target a preview or staging environment, pass `base_url` — it sets both the GraphQL endpoint (`<base_url>/api/graphql`) and the OAuth endpoints (`<base_url>/oauth/token`, `<base_url>/oauth/authorize`):
+
+```python
+from playerdatapy.playerdata_api import PlayerDataAPI
+
+api = PlayerDataAPI(
+    client_id="...",
+    base_url="https://preview.playerdata.co.uk",
+)
+```
+
+If you'd rather not touch the call site, set environment variables instead — they supply the defaults when `base_url` is omitted:
+
+| Variable | Overrides | Default |
+|----------|-----------|---------|
+| `PLAYERDATA_BASE_URL` | API + OAuth base URL | `https://app.playerdata.co.uk` |
+| `PLAYERDATA_GRAPHQL_URL` | GraphQL endpoint only | `<PLAYERDATA_BASE_URL>/api/graphql` |
+
+An explicit `base_url=` argument always wins over the environment variables.
+
 ## Env vars (used in examples)
 
 ```bash

--- a/playerdatapy/auth/authorisation_code_flow.py
+++ b/playerdatapy/auth/authorisation_code_flow.py
@@ -13,8 +13,9 @@ class AuthorisationCodeFlow(AuthorisationCodeFlowBase):
         port: int,
         client_secret: str,
         token_file: Optional[Union[str, Path]] = None,
+        base_url: Optional[str] = None,
     ):
-        super().__init__(client_id, port, token_file)
+        super().__init__(client_id, port, token_file, base_url)
         self.client_secret = client_secret
 
     def _fetch_token(self, code: str) -> dict:

--- a/playerdatapy/auth/authorisation_code_flow_base.py
+++ b/playerdatapy/auth/authorisation_code_flow_base.py
@@ -11,9 +11,13 @@ class AuthorisationCodeFlowBase(BaseAuthFlow):
     """Base class for OAuth2 authorization code flows with token management."""
 
     def __init__(
-        self, client_id: str, port: int, token_file: Optional[Union[str, Path]] = None
+        self,
+        client_id: str,
+        port: int,
+        token_file: Optional[Union[str, Path]] = None,
+        base_url: Optional[str] = None,
     ):
-        super().__init__(client_id, token_file)
+        super().__init__(client_id, token_file, base_url)
         self.server = Server(port)
 
     def authenticate(self, redirect_uri):

--- a/playerdatapy/auth/base_flow.py
+++ b/playerdatapy/auth/base_flow.py
@@ -10,10 +10,15 @@ from .token_storage import default_token_path
 class BaseAuthFlow:
     """Base class for OAuth2 authentication flows with token management."""
 
-    def __init__(self, client_id: str, token_file: Optional[Union[str, Path]] = None):
+    def __init__(
+        self,
+        client_id: str,
+        token_file: Optional[Union[str, Path]] = None,
+        base_url: Optional[str] = None,
+    ):
         self.client_id = client_id
         self.token_file: Path = Path(token_file) if token_file else default_token_path()
-        self.api_base_url = API_BASE_URL
+        self.api_base_url = base_url or API_BASE_URL
         self.oauth_session = None
 
     def get_token(self) -> dict:

--- a/playerdatapy/auth/client_credentials_flow.py
+++ b/playerdatapy/auth/client_credentials_flow.py
@@ -14,8 +14,9 @@ class ClientCredentialsFlow(BaseAuthFlow):
         client_id: str,
         client_secret: str,
         token_file: Optional[Union[str, Path]] = None,
+        base_url: Optional[str] = None,
     ):
-        super().__init__(client_id, token_file)
+        super().__init__(client_id, token_file, base_url)
         self.client_secret = client_secret
 
     def authenticate(self, save_token: bool = True) -> dict:

--- a/playerdatapy/constants.py
+++ b/playerdatapy/constants.py
@@ -1,4 +1,11 @@
 import os
 
-API_BASE_URL = os.environ.get("PLAYERDATA_BASE_URL", "https://app.playerdata.co.uk")
-GRAPHQL_URL = os.environ.get("PLAYERDATA_GRAPHQL_URL", f"{API_BASE_URL}/api/graphql")
+DEFAULT_BASE_URL = "https://app.playerdata.co.uk"
+
+
+def graphql_url_for(base_url: str) -> str:
+    return f"{base_url}/api/graphql"
+
+
+API_BASE_URL = os.environ.get("PLAYERDATA_BASE_URL", DEFAULT_BASE_URL)
+GRAPHQL_URL = os.environ.get("PLAYERDATA_GRAPHQL_URL", graphql_url_for(API_BASE_URL))

--- a/playerdatapy/gqlauth.py
+++ b/playerdatapy/gqlauth.py
@@ -34,6 +34,7 @@ class GraphqlAuth:
         redirect_uri: str = "http://localhost:8888",
         port: int = 8888,
         type: AuthenticationType = AuthenticationType.AUTHORISATION_CODE_FLOW,
+        base_url: Optional[str] = None,
     ):
         self.client_id = client_id
         self.token_file: Path = Path(token_file) if token_file else default_token_path()
@@ -42,21 +43,29 @@ class GraphqlAuth:
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
         self.port = port
+        self.api_base_url = base_url or API_BASE_URL
         self.authenticated_session = self._get_authenticated_session()
 
     def _get_authenticated_session(self):
         match self.authentication_type:
             case AuthenticationType.AUTHORISATION_CODE_FLOW_PCKE:
                 self.authenticator = AuthorisationCodeFlowPCKE(
-                    self.client_id, self.port, self.token_file
+                    self.client_id, self.port, self.token_file, self.api_base_url
                 )
             case AuthenticationType.AUTHORISATION_CODE_FLOW:
                 self.authenticator = AuthorisationCodeFlow(
-                    self.client_id, self.port, self.client_secret, self.token_file
+                    self.client_id,
+                    self.port,
+                    self.client_secret,
+                    self.token_file,
+                    self.api_base_url,
                 )
             case AuthenticationType.CLIENT_CREDENTIALS_FLOW:
                 self.authenticator = ClientCredentialsFlow(
-                    self.client_id, self.client_secret, self.token_file
+                    self.client_id,
+                    self.client_secret,
+                    self.token_file,
+                    self.api_base_url,
                 )
 
         try:
@@ -68,7 +77,7 @@ class GraphqlAuth:
         return OAuth2Session(
             self.client_id,
             token=token,
-            auto_refresh_url=f"{API_BASE_URL}/oauth/token",
+            auto_refresh_url=f"{self.api_base_url}/oauth/token",
             token_updater=self.authenticator.save_token,
         )
 

--- a/playerdatapy/playerdata_api.py
+++ b/playerdatapy/playerdata_api.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 from .gqlauth import GraphqlAuth, AuthenticationType
 from .gqlclient import Client
 from .base_operation import GraphQLField
-from playerdatapy.constants import GRAPHQL_URL
+from playerdatapy.constants import GRAPHQL_URL, graphql_url_for
 
 
 class PlayerDataAPI(GraphqlAuth):
@@ -16,6 +16,7 @@ class PlayerDataAPI(GraphqlAuth):
         token_file: Optional[Union[str, Path]] = None,
         port: int = 8888,
         authentication_type: AuthenticationType = AuthenticationType.AUTHORISATION_CODE_FLOW,
+        base_url: Optional[str] = None,
     ):
         super().__init__(
             client_id=client_id,
@@ -24,9 +25,11 @@ class PlayerDataAPI(GraphqlAuth):
             token_file=token_file,
             port=port,
             type=authentication_type,
+            base_url=base_url,
         )
+        graphql_url = graphql_url_for(base_url) if base_url else GRAPHQL_URL
         self.client = Client(
-            url=GRAPHQL_URL,
+            url=graphql_url,
             headers={"Authorization": f"Bearer {self._get_authentication_token()}"},
         )
 

--- a/tests/auth/test_base_flow.py
+++ b/tests/auth/test_base_flow.py
@@ -23,6 +23,15 @@ class TestBaseAuthFlow:
         assert flow.token_file == Path(".test_token")
         assert flow.oauth_session is None
 
+    def test_init_with_base_url(self):
+        """Test base_url overrides the default API base URL."""
+        flow = BaseAuthFlow(
+            client_id="test_client",
+            token_file=".test_token",
+            base_url="https://preview.playerdata.co.uk",
+        )
+        assert flow.api_base_url == "https://preview.playerdata.co.uk"
+
     def test_save_token(self):
         """Test saving token to file."""
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".token") as f:

--- a/tests/test_gqlauth.py
+++ b/tests/test_gqlauth.py
@@ -5,6 +5,7 @@ import pytest
 from oauthlib.oauth2 import TokenExpiredError  # type: ignore[import-untyped]
 
 from playerdatapy.auth.token_storage import default_token_path
+from playerdatapy.constants import API_BASE_URL
 from playerdatapy.gqlauth import GraphqlAuth, AuthenticationType
 
 
@@ -37,7 +38,7 @@ class TestGraphqlAuth:
         assert auth.authentication_type == AuthenticationType.CLIENT_CREDENTIALS_FLOW
         assert auth.authenticator == mock_authenticator
         mock_flow_class.assert_called_once_with(
-            "test_client", "test_secret", default_token_path()
+            "test_client", "test_secret", default_token_path(), API_BASE_URL
         )
 
     @patch("playerdatapy.gqlauth.OAuth2Session")
@@ -68,7 +69,7 @@ class TestGraphqlAuth:
         assert auth.port == 9999
         assert auth.authentication_type == AuthenticationType.AUTHORISATION_CODE_FLOW
         mock_flow_class.assert_called_once_with(
-            "test_client", 9999, "test_secret", Path(".test_token")
+            "test_client", 9999, "test_secret", Path(".test_token"), API_BASE_URL
         )
 
     @patch("playerdatapy.gqlauth.OAuth2Session")
@@ -96,7 +97,40 @@ class TestGraphqlAuth:
             auth.authentication_type == AuthenticationType.AUTHORISATION_CODE_FLOW_PCKE
         )
         mock_flow_class.assert_called_once_with(
-            "test_client", 8888, Path(".test_token")
+            "test_client", 8888, Path(".test_token"), API_BASE_URL
+        )
+
+    @patch("playerdatapy.gqlauth.OAuth2Session")
+    @patch("playerdatapy.gqlauth.ClientCredentialsFlow")
+    def test_init_with_base_url(self, mock_flow_class, mock_session_class):
+        """Test base_url overrides the default and reaches the flow and refresh URL."""
+        mock_authenticator = MagicMock()
+        mock_authenticator.get_token.return_value = {"access_token": "test_token"}
+        mock_flow_class.return_value = mock_authenticator
+
+        mock_session = MagicMock()
+        mock_session.token = {"access_token": "test_token"}
+        mock_session_class.return_value = mock_session
+
+        auth = GraphqlAuth(
+            client_id="test_client",
+            client_secret="test_secret",
+            type=AuthenticationType.CLIENT_CREDENTIALS_FLOW,
+            base_url="https://preview.playerdata.co.uk",
+        )
+
+        assert auth.api_base_url == "https://preview.playerdata.co.uk"
+        mock_flow_class.assert_called_once_with(
+            "test_client",
+            "test_secret",
+            default_token_path(),
+            "https://preview.playerdata.co.uk",
+        )
+        mock_session_class.assert_called_once_with(
+            "test_client",
+            token={"access_token": "test_token"},
+            auto_refresh_url="https://preview.playerdata.co.uk/oauth/token",
+            token_updater=mock_authenticator.save_token,
         )
 
     @patch("playerdatapy.gqlauth.OAuth2Session")

--- a/tests/test_playerdata_api.py
+++ b/tests/test_playerdata_api.py
@@ -76,6 +76,37 @@ class TestPlayerdataAPI:
         )
         assert interface.client == mock_client_instance
 
+    @patch("playerdatapy.playerdata_api.Client")
+    @patch("playerdatapy.gqlauth.OAuth2Session")
+    @patch("playerdatapy.gqlauth.ClientCredentialsFlow")
+    def test_init_with_base_url(
+        self, mock_flow_class, mock_session_class, mock_client_class
+    ):
+        """Test base_url derives the GraphQL URL and reaches the auth layer."""
+        mock_authenticator = MagicMock()
+        mock_authenticator.get_token.return_value = {"access_token": "test_token"}
+        mock_flow_class.return_value = mock_authenticator
+
+        mock_session = MagicMock()
+        mock_session.token = {"access_token": "test_token"}
+        mock_session_class.return_value = mock_session
+
+        mock_client_instance = MagicMock()
+        mock_client_class.return_value = mock_client_instance
+
+        interface = PlayerDataAPI(
+            client_id="test_client",
+            client_secret="test_secret",
+            authentication_type=AuthenticationType.CLIENT_CREDENTIALS_FLOW,
+            base_url="https://preview.playerdata.co.uk",
+        )
+
+        assert interface.api_base_url == "https://preview.playerdata.co.uk"
+        mock_client_class.assert_called_once_with(
+            url="https://preview.playerdata.co.uk/api/graphql",
+            headers={"Authorization": "Bearer test_token"},
+        )
+
     @pytest.mark.asyncio
     @patch("playerdatapy.playerdata_api.Client")
     @patch("playerdatapy.gqlauth.OAuth2Session")


### PR DESCRIPTION
## Summary

Adds an optional `base_url` parameter across the client and auth layer so the SDK can be pointed at a non-production environment (e.g. a preview environment) at construction time, rather than relying solely on import-time environment variables. Defaults are unchanged, so existing code keeps working exactly as before.

## Changes

- Added an optional `base_url` parameter to `PlayerDataAPI`, `GraphqlAuth`, and all auth flows (`BaseAuthFlow`, `AuthorisationCodeFlow(Base)`, `AuthorisationCodeFlowPCKE`, `ClientCredentialsFlow`).
- When `base_url` is provided it drives both the GraphQL endpoint (`<base_url>/api/graphql`) and the OAuth endpoints (`<base_url>/oauth/token`, `<base_url>/oauth/authorize`).
- Refactored `constants.py` to expose `DEFAULT_BASE_URL` and a `graphql_url_for()` helper; falls back to the existing `PLAYERDATA_BASE_URL` / `PLAYERDATA_GRAPHQL_URL` env vars when `base_url` is omitted.
- Documented the new usage in a "Pointing at a different environment" section in `docs/auth.md`.

## Testing

Extended the auth flow, `GraphqlAuth`, and `PlayerDataAPI` test suites to cover the new parameter and the unchanged default behaviour. Lint and the full test suite pass locally.

## Usage

```python
PlayerDataAPI(client_id="...", base_url="https://preview.playerdata.co.uk")
```
