### PR TITLE
docs: note Client Credentials grant supports mutations

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -23,7 +23,7 @@ PlayerData API uses **OAuth 2.0**. Two grant types depending on integration.
 **Client Credentials Grant** — server-to-server.
 
 - No user sign-in, Client ID + Secret
-- **Read-only** (queries only)
+- Read **and** write (queries + mutations)
 - Org-level data access
 - Service account must be granted org access
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,8 +2,8 @@
 
 ### Which authentication method should I use?
 
-- **Authorisation Code Grant** — user-facing apps, or when mutations are required
-- **Client Credentials Grant** — backend, read-only integrations
+- **Authorisation Code Grant** — user-facing apps, per-user access
+- **Client Credentials Grant** — backend integrations, org-level access
 
 ### Why can't I access a club's data?
 
@@ -11,7 +11,7 @@ Using Authorisation Code Grant: the authenticated user/service is not listed as 
 
 ### Can I write or update data (mutate) via the API?
 
-Yes, but only under the Authorisation Code Grant.
+Yes — under both the Authorisation Code Grant and the Client Credentials Grant.
 
 ### Is the GraphiQL Playground safe to use?
 

--- a/docs/gen_ref.py
+++ b/docs/gen_ref.py
@@ -39,7 +39,7 @@ SECTION_INTROS: dict[str, str] = {
     "Authentication": "OAuth2 flows and token persistence. Used internally by `PlayerDataAPI`.",
     "GraphQL Client": "Low-level async HTTP client. Use for raw GraphQL strings.",
     "Queries": "Typed query builders generated from the schema. Pass to `PlayerDataAPI.run_queries`.",
-    "Mutations": "Typed mutation builders. Require Authorisation Code Grant — Client Credentials is read-only.",
+    "Mutations": "Typed mutation builders. Usable under both the Authorisation Code and Client Credentials grants.",
     "Fields": "Field builders used when composing queries and mutations.",
     "Input Types": "Pydantic models for query/mutation arguments. Field descriptions come from the schema.",
     "Enums": "String-valued enumerations from the schema. Class and member docstrings come from schema descriptions.",


### PR DESCRIPTION
## Summary

Updates the documentation to reflect that the Client Credentials OAuth grant now supports mutations. Previously the docs described this grant as read-only, but the server no longer enforces that restriction, so backend integrations can run both queries and mutations.

## Changes

- Mark the Client Credentials grant as supporting both read and write in the auth guide
- Update the FAQ guidance on choosing an auth method and the "can I mutate?" answer
- Correct the Mutations reference blurb to note both grants can run mutations

## Notes

Docs-only change. The read-only restriction was enforced server-side and has since been lifted; no Python source or behavior changes are involved.