### PR TITLE
fix: restore PlayerDataAPI export from package root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Repo-specific guidance for AI assistants (Claude Code, Cursor, etc.). Humans, sk
 
 - Python package `playerdatapy` — typed client for the PlayerData GraphQL API.
 - Generated from `schema.graphql` by `ariadne-codegen` (config in `pyproject.toml` under `[tool.ariadne-codegen]`). `schema.graphql` is refreshed from the public SDL at `https://app.playerdata.co.uk/api/schema.graphql`.
-- Custom codegen plugin at `codegen_plugins/docstrings.py` injects schema descriptions into generated enums.
+- Custom codegen plugins: `codegen_plugins/docstrings.py` injects schema descriptions into generated enums; `codegen_plugins/public_api.py` re-exports hand-written modules (`PlayerDataAPI`) from the generated `__init__.py`.
 - Docs site at `docs/`, built with MkDocs Material + mkdocstrings, deployed to GitHub Pages via `.github/workflows/docs.yml`.
 - Examples in `examples/direct/` (raw GraphQL) and `examples/pydantic/` (typed `PlayerDataAPI` — preferred).
 
@@ -24,6 +24,7 @@ These are output of `uv run ariadne-codegen` and excluded from ruff:
 - `playerdatapy/base_model.py`
 - `playerdatapy/base_operation.py`
 - `playerdatapy/async_base_client.py`
+- `playerdatapy/__init__.py` — includes the hand-written re-exports only because the `public_api` plugin adds them; never add exports to it by hand
 
 Any edits will be wiped on next codegen run. To change them, edit `schema.graphql` (or update upstream schema in the `PlayerData/api` repo) or the codegen plugin.
 

--- a/codegen_plugins/public_api.py
+++ b/codegen_plugins/public_api.py
@@ -1,0 +1,53 @@
+"""ariadne-codegen plugin: re-export hand-written public API from the package root.
+
+The generated ``__init__.py`` only knows about codegen output, so any hand-written
+module (``playerdata_api.py`` etc.) silently drops out of the package root on every
+regeneration — see PlayerData/analysis-services breakage after v1.11.1. This plugin
+adds the exports back during codegen so they survive the nightly regen.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from ariadne_codegen.plugins.base import Plugin
+
+PUBLIC_EXPORTS: dict[str, list[str]] = {
+    "playerdata_api": ["PlayerDataAPI"],
+}
+
+
+class PublicApiExportsPlugin(Plugin):
+    def generate_init_module(self, module: ast.Module) -> ast.Module:
+        imports = [
+            ast.ImportFrom(module=source, names=[ast.alias(name=name)], level=1)
+            for source, names in PUBLIC_EXPORTS.items()
+            for name in names
+        ]
+
+        last_import_index = max(
+            (
+                i
+                for i, stmt in enumerate(module.body)
+                if isinstance(stmt, ast.ImportFrom)
+            ),
+            default=-1,
+        )
+        module.body[last_import_index + 1 : last_import_index + 1] = imports
+
+        for stmt in module.body:
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+                and stmt.targets[0].id == "__all__"
+                and isinstance(stmt.value, ast.List)
+            ):
+                stmt.value.elts.extend(
+                    ast.Constant(value=name)
+                    for names in PUBLIC_EXPORTS.values()
+                    for name in names
+                )
+                stmt.value.elts.sort(key=lambda elt: ast.literal_eval(elt))
+
+        return module

--- a/playerdatapy/__init__.py
+++ b/playerdatapy/__init__.py
@@ -203,6 +203,7 @@ from .input_types import (
     VideoClipOverlayInput,
     VideoRecordingAttributes,
 )
+from .playerdata_api import PlayerDataAPI
 
 __all__ = [
     "AccelzoneLowerBoundsInput",
@@ -317,6 +318,7 @@ __all__ = [
     "PitchCoordinateAttributes",
     "PitchCoordinateSetAttributes",
     "Platform",
+    "PlayerDataAPI",
     "PositionAttributes",
     "PreprocessingOutputFileTypeEnum",
     "ProcessingWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ target_package_name = "playerdatapy"
 enable_custom_operations = true
 client_file_name = "gqlclient"
 client_class_name = "GraphqlClient"
-plugins = ["codegen_plugins.docstrings.EnumDocstringsPlugin"]
+plugins = [
+    "codegen_plugins.docstrings.EnumDocstringsPlugin",
+    "codegen_plugins.public_api.PublicApiExportsPlugin",
+]
 
 [tool.ruff.lint]
 ignore = ["F405", "F403"]

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -1,0 +1,19 @@
+import playerdatapy
+
+
+class TestPublicExports:
+    """Hand-written modules must stay importable from the package root.
+
+    The generated ``__init__.py`` is rewritten on every codegen run; the
+    PublicApiExportsPlugin (codegen_plugins/public_api.py) re-adds these
+    exports. If this test fails, the plugin was dropped from
+    ``[tool.ariadne-codegen]`` or codegen ran without it (as happened in
+    v1.11.1).
+    """
+
+    def test_playerdata_api_import(self):
+        from playerdatapy import PlayerDataAPI
+        from playerdatapy.playerdata_api import PlayerDataAPI as canonical
+
+        assert PlayerDataAPI is canonical
+        assert "PlayerDataAPI" in playerdatapy.__all__


### PR DESCRIPTION
## Problem

The nightly codegen regeneration rewrites `playerdatapy/__init__.py`. In v1.11.1 that silently dropped the hand-added `from .playerdata_api import PlayerDataAPI` re-export, breaking `from playerdatapy import PlayerDataAPI` for downstream consumers — PlayerData/analysis-services#4064 had to pin back to 1.11.0. The export is still missing on `main`, so every release since 1.11.0 has shipped without it.

## Fix

- **`codegen_plugins/public_api.py`** — new `PublicApiExportsPlugin` that injects hand-written public exports (currently just `PlayerDataAPI`) into the generated `__init__.py` during codegen, so they survive every regen. Verified idempotent across repeated runs.
- **`tests/test_public_exports.py`** — regression test asserting the root import works and `PlayerDataAPI` is in `__all__`, so a regen without the plugin fails CI instead of shipping.
- **`CLAUDE.md`** — `__init__.py` added to the codegen-owned file list (its omission is how the hand-edit got made in the first place).

## Verification

- `uv run ariadne-codegen` restores exactly the two dropped lines (import + `__all__` entry, sorted position); no other generated files change.
- Second codegen run produces no diff (nightly regen safe).
- `pytest`: 40 passed. `ruff check` / `ruff format --check`: clean.