### PR TITLE
feat: add signed download URLs to VideoFragment

### DIFF
--- a/playerdatapy/custom_fields.py
+++ b/playerdatapy/custom_fields.py
@@ -32155,6 +32155,16 @@ class VideoFragmentFields(GraphQLField):
     "Whether the processing intermediate file is attached"
 
     @classmethod
+    def processing_intermediate_signed_url(cls) -> "SignedUrlFields":
+        """A signed URL to download the processing intermediate file (the fragment's analysis state)"""
+        return SignedUrlFields("processingIntermediateSignedUrl")
+
+    @classmethod
+    def raw_signed_url(cls) -> "SignedUrlFields":
+        """A signed URL to download the raw uploaded fragment video file"""
+        return SignedUrlFields("rawSignedUrl")
+
+    @classmethod
     def video_variants(
         cls, *, limit: Optional[int] = None, offset: Optional[int] = None
     ) -> "VideoVariantFields":
@@ -32169,7 +32179,10 @@ class VideoFragmentFields(GraphQLField):
         return VideoVariantFields("videoVariants", arguments=cleared_arguments)
 
     def fields(
-        self, *subfields: Union[VideoFragmentGraphQLField, "VideoVariantFields"]
+        self,
+        *subfields: Union[
+            VideoFragmentGraphQLField, "SignedUrlFields", "VideoVariantFields"
+        ],
     ) -> "VideoFragmentFields":
         """Subfields should come from the VideoFragmentFields class"""
         self._subfields.extend(subfields)

--- a/schema.graphql
+++ b/schema.graphql
@@ -37674,6 +37674,16 @@ type VideoFragment implements VideoSourceInterface {
   processingIntermediateFileAttached: Boolean!
 
   """
+  A signed URL to download the processing intermediate file (the fragment's analysis state)
+  """
+  processingIntermediateSignedUrl: SignedUrl
+
+  """
+  A signed URL to download the raw uploaded fragment video file
+  """
+  rawSignedUrl: SignedUrl
+
+  """
   The video variants belonging to this video source
   """
   videoVariants(

--- a/tests/test_video_fragment_signed_urls.py
+++ b/tests/test_video_fragment_signed_urls.py
@@ -1,0 +1,33 @@
+from graphql import print_ast
+
+from playerdatapy.custom_fields import SignedUrlFields, VideoFragmentFields
+
+
+class TestVideoFragmentSignedUrls:
+    """The staff-only signed-download-URL fields on VideoFragment."""
+
+    def _render(self, *subfields):
+        fragment = VideoFragmentFields("videoFragments").fields(*subfields)
+        return print_ast(fragment.to_ast(0))
+
+    def test_raw_signed_url_selection(self):
+        query = self._render(
+            VideoFragmentFields.raw_signed_url().fields(
+                SignedUrlFields.signed_url, SignedUrlFields.expires_at
+            )
+        )
+
+        assert "rawSignedUrl" in query
+        assert "signedUrl" in query
+        assert "expiresAt" in query
+
+    def test_processing_intermediate_signed_url_selection(self):
+        query = self._render(
+            VideoFragmentFields.processing_intermediate_signed_url().fields(
+                SignedUrlFields.signed_url, SignedUrlFields.expires_at
+            )
+        )
+
+        assert "processingIntermediateSignedUrl" in query
+        assert "signedUrl" in query
+        assert "expiresAt" in query


### PR DESCRIPTION
## Summary

Adds two read-only, staff-only signed-download-URL fields to the `VideoFragment` GraphQL type in the typed client, so consumers can select them: `rawSignedUrl` (the raw uploaded fragment) and `processingIntermediateSignedUrl` (the per-fragment analysis `.pklz`). Both return the existing `SignedUrl` type (`signedUrl` + `expiresAt`). This ports the API-side functionality merged in PlayerData/api#13691 (for the videobucket CLI) into the playerdatapy client.

## Changes

- Added `rawSignedUrl` and `processingIntermediateSignedUrl` to `VideoFragment` in `schema.graphql`, matching the upstream SDL exactly.
- Regenerated the client via ariadne-codegen so the new fields are selectable.
- Added a regression test guarding that both fields render into a query selection.

## Testing

- `uv run ruff check`
- `uv run pytest`

## Notes

This was a targeted schema edit rather than a full public-SDL refresh, to keep the diff scoped; nightly codegen CI will reconcile the rest. `playerdatapy/custom_fields.py` is regenerated output, not hand-edited.