### PR TITLE
docs: add raw data export guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ export CLIENT_SECRET=your_client_secret
 export CLUB_ID=your_club_id
 ```
 
+### Exporting raw data
+
+Per-sample GPS, positioning (LPS/UWB), IMU, and heart-rate data can be exported as CSV or JSON, for a single athlete or a whole session:
+
+```bash
+python examples/direct/raw_data_export.py
+```
+
+See [Raw Data Export](https://playerdata.github.io/playerdatapy/raw-data-export/) for the mutations, statuses, output layouts, and column schemas.
+
 ## Authentication Types
 
 These authentication types are set out in the `playerdatapy.gqlauth.AuthenticationType` enum.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -49,4 +49,5 @@ Response:
 - **[Authentication](../auth.md)** — get an access token via OAuth2
 - **[Concepts](../concepts.md)** — understand the schema's core types
 - **[Metrics](../metrics.md)** — explore the data available per session
+- **[Raw Data Export](../raw-data-export.md)** — download per-sample GPS, positioning, IMU, and heart-rate data
 - **[Clients](../clients.md)** — Python SDK + access patterns for other languages

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -90,3 +90,9 @@ asyncio.run(main())
 ```
 
 For the typed/pydantic equivalent, see [`examples/pydantic/quick_start.py`](https://github.com/PlayerData/playerdatapy/blob/main/examples/pydantic/quick_start.py).
+
+## Raw data export
+
+Request a CSV or JSON export for one athlete or a whole session, poll it to a deadline, download it, and read an athlete's CSV out of the session zip.
+
+See [Raw Data Export](raw-data-export.md) for the mutations, statuses, output layouts, and column schemas, and [`examples/direct/raw_data_export.py`](https://github.com/PlayerData/playerdatapy/blob/main/examples/direct/raw_data_export.py) for the runnable script.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Designed for technology partners, clubs, federations, analytics teams, research 
 - :material-shield-lock: **[Authentication](auth.md)** — OAuth2 grant types
 - :material-book-open-variant: **[Concepts](concepts.md)** — Organisation, Club, Session, Athlete
 - :material-chart-line: **[Metrics](metrics.md)** — distance, speed, intensity, raw GPS
+- :material-download: **[Raw Data Export](raw-data-export.md)** — per-sample GPS, positioning, IMU, heart rate as CSV or JSON
 - :material-language-python: **[Python SDK](python/index.md)** — `pip install playerdatapy`
 - :material-language-r: **[R wrapper](https://github.com/PlayerData/playerdatar)** — `remotes::install_github("PlayerData/playerdatar")`
 - :material-application: **[Other Clients](clients.md)** — curl, JS, Go, anything that speaks HTTP

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -106,6 +106,8 @@ Fields returning `[TimeSeriesData!]`, sampled at 5-minute intervals:
 
 Latitude, longitude, speed, timestamps per athlete session participation via dedicated schema fields.
 
+For per-sample GPS, LPS/UWB, IMU, and heart-rate data as downloadable CSV or JSON files, see [Raw Data Export](raw-data-export.md).
+
 ## Configured vs all metrics
 
 **Configured metrics** — club has enabled in the app. Shown to staff + athletes. Queryable at session, participation, segment level.

--- a/docs/raw-data-export.md
+++ b/docs/raw-data-export.md
@@ -1,0 +1,319 @@
+# Raw Data Export
+
+Per-sample data recorded during a session — GPS, local positioning (LPS/UWB), IMU, and heart rate — is downloadable as CSV or JSON.
+
+Two mutations cover the two scopes:
+
+| Mutation | Scope | Result |
+|---|---|---|
+| `requestRawDataExport` | One athlete in one session (a session participation) | A single file, or a zip for `FULL` + `CSV` |
+| `requestSessionRawDataExport` | A whole session | Always a zip, one folder per athlete |
+
+Both work the same way:
+
+1. Call the mutation to request an export. Preparation starts in the background.
+2. Call it again with the same arguments to poll. Repeat calls are safe and never duplicate work.
+3. Once `status` is `READY`, the response carries a time-limited `downloadUrl`.
+
+Prefer `requestSessionRawDataExport` over looping the per-participation mutation across a squad. Requesting a whole session requires staff-level access to the club that owns it; the per-participation mutation is the one for an athlete downloading their own data.
+
+## Participation exports
+
+```graphql
+mutation($id: ID!, $dataType: RawDataExportTypeEnum!, $format: RawDataExportFormatEnum!) {
+  requestRawDataExport(sessionParticipationId: $id, dataType: $dataType, format: $format) {
+    status
+    downloadUrl
+    errors { fullMessages }
+  }
+}
+```
+
+| Argument | Type | Description |
+|---|---|---|
+| `sessionParticipationId` | `ID!` | The session participation to export. IDs come from the `sessions` query. |
+| `dataType` | `RawDataExportTypeEnum!` | `GPS`, `LPS` (or `UWB`), `IMU`, `IMU_ACCELERATION`, `HEARTRATE`, or `FULL` for every type recorded |
+| `format` | `RawDataExportFormatEnum!` | `CSV` or `JSON` |
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `RawDataStatusEnum!` | `READY`, `PROCESSING`, or `UNAVAILABLE` |
+| `downloadUrl` | `String` | Time-limited link to the export file; present once `status` is `READY` |
+| `errors` | `[ValidationError!]!` | Validation errors, e.g. an unknown `sessionParticipationId` |
+
+`LPS` and `UWB` name the same data — local positioning recorded by an LPS installation. Use whichever you prefer; the exported files are always named `uwb.*`.
+
+## Session exports
+
+Arguments match `requestRawDataExport`, with a session ID in place of a participation ID.
+
+```graphql
+mutation($id: ID!, $dataType: RawDataExportTypeEnum!, $format: RawDataExportFormatEnum!) {
+  requestSessionRawDataExport(sessionId: $id, dataType: $dataType, format: $format) {
+    status
+    downloadUrl
+    unavailableParticipationIds
+    errors { fullMessages }
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `RawDataStatusEnum!` | `READY`, `PROCESSING`, or `UNAVAILABLE` |
+| `downloadUrl` | `String` | Time-limited link to the zip; present once `status` is `READY` |
+| `unavailableParticipationIds` | `[ID!]!` | Participations left out of the export |
+| `errors` | `[ValidationError!]!` | Validation errors, e.g. an unknown `sessionId` |
+
+!!! note "Expect at least two calls"
+    The call that finds every athlete's data ready is the one that starts building the zip, so it returns `PROCESSING`. `READY` arrives on a later poll.
+
+### Which athletes are included
+
+The zip contains a folder only for athletes whose data could be produced. Everyone else is listed in `unavailableParticipationIds` — usually because the type wasn't recorded for them, or because their device has not finished uploading.
+
+- `unavailableParticipationIds` describes the file you are downloading. It is fixed when the zip is built and stays the same for as long as that export is reused.
+- A session export does not wait for a slow-syncing device. That athlete is left out rather than holding up everyone else. To include them, request again once the reuse window has lapsed.
+
+## Statuses
+
+| Status | Meaning |
+|---|---|
+| `PROCESSING` | The export is being prepared. Poll again — every 15–30 seconds is a good default. |
+| `READY` | The file is built. Download it from `downloadUrl`. |
+| `UNAVAILABLE` | Participation scope: this data type was not recorded, e.g. no heart-rate monitor worn. Session scope: no athlete in the session recorded it. |
+
+A participation with no data can report `PROCESSING` for up to 24 hours before it settles on `UNAVAILABLE`, so poll against a deadline rather than indefinitely.
+
+## Export lifecycle
+
+- **Download links expire after 15 minutes.** Call the mutation again for a fresh link.
+- **Recent exports are reused for about 45 minutes.** Requesting the same export inside that window returns the already-built file straight away. After it, the export is rebuilt, so expect `PROCESSING` again briefly.
+- **Preparation time varies** with session length and data type. A `FULL` export of a long session takes longer than one short data type.
+- All timestamps in the data are **UTC**.
+
+## Output formats
+
+Participation scope:
+
+| `dataType` | `format` | You get |
+|---|---|---|
+| A single type | `CSV` | One `.csv` for that type |
+| A single type | `JSON` | `{ "gps": [ ...rows ] }` |
+| `FULL` | `JSON` | Every recorded type in one document: `{ "gps": [...], "uwb": [...], ... }` |
+| `FULL` | `CSV` | A `.zip` with one CSV per recorded type at the root — `gps.csv`, `imu.csv`, ... |
+
+Session scope is always a zip, whatever the format, with one folder per athlete named after their session participation ID:
+
+| `dataType` | `format` | Entries |
+|---|---|---|
+| A single type | `CSV` | `<participation-id>/gps.csv` |
+| A single type | `JSON` | `<participation-id>/gps.json` |
+| `FULL` | `JSON` | `<participation-id>/full.json` |
+| `FULL` | `CSV` | `<participation-id>/gps.csv`, `<participation-id>/imu.csv`, ... |
+
+```text
+session_raw_data_<id>.zip
+├── 0f9c2b41-8d3e-4a17-9c55-2e6b1f04a7d2/
+│   ├── gps.csv
+│   ├── imu.csv
+│   └── heartrate.csv
+└── 7b1e6a90-5c22-4f8b-b3d1-9a4c8e2f61b0/
+    ├── gps.csv
+    └── imu.csv
+```
+
+There are no nested zips to unpack — inner archives are flattened. An athlete listed in `unavailableParticipationIds` has no folder at all. Files inside a session zip are byte-identical to what the per-participation mutation returns, so the schemas below apply to both scopes.
+
+## Data schemas
+
+### GPS
+
+Satellite positioning samples, roughly 10 per second.
+
+| Column | Type | Description |
+|---|---|---|
+| `time` | integer | Sample time as Unix epoch milliseconds |
+| `timestamp` | datetime | The same instant as ISO 8601 (UTC, millisecond precision) |
+| `latitude` | number | Latitude in decimal degrees |
+| `longitude` | number | Longitude in decimal degrees |
+| `speed` | number | Speed in metres per second |
+| `x` | number | Position on the local pitch coordinate system, metres |
+| `y` | number | Position on the local pitch coordinate system, metres |
+| `distance_delta` | number | Distance covered since the previous sample, metres |
+
+```text
+time,timestamp,latitude,longitude,speed,x,y,distance_delta
+1784226737100,2026-07-16T18:32:17.100Z,51.446144,-0.089322,3.42,12.84,7.19,0.34
+1784226737200,2026-07-16T18:32:17.200Z,51.446151,-0.089310,3.51,13.18,7.55,0.49
+```
+
+### LPS / UWB
+
+Local positioning samples from an LPS installation.
+
+| Column | Type | Description |
+|---|---|---|
+| `x` | number | Position on the local coordinate system, metres |
+| `y` | number | Position on the local coordinate system, metres |
+| `dx` | number | Change in `x` since the previous sample, metres |
+| `dy` | number | Change in `y` since the previous sample, metres |
+| `time` | integer | Sample time as Unix epoch milliseconds |
+| `timestamp` | datetime | The same instant as ISO 8601 (UTC, millisecond precision) |
+| `distance_delta` | number | Distance covered since the previous sample, metres |
+| `speed` | number | Speed in metres per second |
+
+### IMU
+
+Inertial measurement samples, roughly 50 per second: acceleration plus device orientation.
+
+| Column | Type | Description |
+|---|---|---|
+| `time` | datetime | Sample time, ISO 8601 (UTC, millisecond precision) |
+| `acceleration_x` / `acceleration_y` / `acceleration_z` | number | Acceleration along each axis, m/s² |
+| `orientation_x` / `orientation_y` / `orientation_z` / `orientation_w` | number | Device orientation as a unit quaternion |
+
+### IMU_ACCELERATION
+
+Per-axis acceleration samples, including which sensor recorded them.
+
+| Column | Type | Description |
+|---|---|---|
+| `time` | datetime | Sample time, ISO 8601 (UTC, millisecond precision) |
+| `x` / `y` / `z` | number | Acceleration along each axis |
+| `sensor_location` | integer | Code identifying where on the body the sensor was worn |
+
+### HEARTRATE
+
+Roughly one sample per second.
+
+| Column | Type | Description |
+|---|---|---|
+| `time` | datetime | Sample time, ISO 8601 (UTC, millisecond precision) |
+| `mean_bpm` | number | Mean heart rate, beats per minute |
+
+!!! note "Time columns"
+    `GPS` and `LPS`/`UWB` carry both `time` (epoch milliseconds, convenient for numeric processing) and `timestamp` (ISO 8601). For `IMU`, `IMU_ACCELERATION`, and `HEARTRATE`, `time` is the ISO 8601 column.
+
+The `satellites` column visible on some other raw-data endpoints is deliberately excluded from GPS and UWB exports.
+
+## Python example
+
+Authenticate, find a participation, request a GPS export, poll to a deadline, download.
+
+```python
+import asyncio
+import os
+import time
+
+import httpx
+
+from playerdatapy.constants import GRAPHQL_URL
+from playerdatapy.gqlauth import AuthenticationType, GraphqlAuth
+from playerdatapy.gqlclient import Client
+
+auth = GraphqlAuth(
+    client_id=os.environ["CLIENT_ID"],
+    client_secret=os.environ["CLIENT_SECRET"],
+    type=AuthenticationType.CLIENT_CREDENTIALS_FLOW,
+)
+
+client = Client(
+    url=GRAPHQL_URL,
+    headers={
+        "Authorization": f"Bearer {auth.authenticated_session.token['access_token']}"
+    },
+)
+
+REQUEST_RAW_DATA_EXPORT = """
+mutation($id: ID!, $dataType: RawDataExportTypeEnum!, $format: RawDataExportFormatEnum!) {
+  requestRawDataExport(sessionParticipationId: $id, dataType: $dataType, format: $format) {
+    status
+    downloadUrl
+    errors { fullMessages }
+  }
+}
+"""
+
+
+async def request_raw_data(
+    session_participation_id: str,
+    data_type: str = "GPS",
+    format: str = "CSV",
+    poll_interval: float = 15.0,
+    timeout: float = 900.0,
+) -> str:
+    variables = {
+        "id": session_participation_id,
+        "dataType": data_type,
+        "format": format,
+    }
+    deadline = time.monotonic() + timeout
+
+    while True:
+        response = await client.execute(
+            query=REQUEST_RAW_DATA_EXPORT, variables=variables
+        )
+        result = client.get_data(response)["requestRawDataExport"]
+
+        if result["errors"]:
+            messages = [m for e in result["errors"] for m in e["fullMessages"]]
+            raise RuntimeError(f"Export failed: {messages}")
+        if result["status"] == "READY":
+            return result["downloadUrl"]
+        if result["status"] == "UNAVAILABLE":
+            raise RuntimeError(f"No {data_type} data for this participation")
+        if time.monotonic() + poll_interval > deadline:
+            raise TimeoutError(f"Export still preparing after {timeout:.0f}s")
+
+        await asyncio.sleep(poll_interval)
+
+
+async def download(url: str, path: str) -> None:
+    async with httpx.AsyncClient(timeout=60.0) as http:
+        response = await http.get(url)
+        response.raise_for_status()
+        with open(path, "wb") as file:
+            file.write(response.content)
+
+
+async def main() -> None:
+    url = await request_raw_data(os.environ["SESSION_PARTICIPATION_ID"])
+    await download(url, "gps.csv")
+
+
+asyncio.run(main())
+```
+
+The `timeout` matters: a participation with no data can report `PROCESSING` for up to 24 hours before it latches to `UNAVAILABLE`, so an unbounded poll loop can hang for a day.
+
+### Reading a session zip
+
+The session mutation polls identically. It returns a zip plus the athletes it left out, and individual CSVs can be read without extracting the archive.
+
+```python
+import zipfile
+
+import polars as pl
+
+REQUEST_SESSION_RAW_DATA_EXPORT = """
+mutation($id: ID!, $dataType: RawDataExportTypeEnum!, $format: RawDataExportFormatEnum!) {
+  requestSessionRawDataExport(sessionId: $id, dataType: $dataType, format: $format) {
+    status
+    downloadUrl
+    unavailableParticipationIds
+    errors { fullMessages }
+  }
+}
+"""
+
+
+def athlete_frame(zip_path: str, participation_id: str) -> pl.DataFrame:
+    with zipfile.ZipFile(zip_path) as archive:
+        with archive.open(f"{participation_id}/gps.csv") as csv_file:
+            return pl.read_csv(csv_file)
+```
+
+Polars ships as a `playerdatapy` dependency; `pandas.read_csv` accepts the same file object.
+
+A runnable version of both flows, including session listing and zip inspection, is in [`examples/direct/raw_data_export.py`](https://github.com/PlayerData/playerdatapy/blob/main/examples/direct/raw_data_export.py).

--- a/examples/direct/README.md
+++ b/examples/direct/README.md
@@ -22,6 +22,16 @@ export CLIENT_SECRET=your_client_secret
 export CLUB_ID=your_club_id
 ```
 
+## Raw Data Export
+
+`raw_data_export.py` requests raw session data as CSV or JSON, for one athlete or a whole session:
+
+```bash
+python examples/direct/raw_data_export.py
+```
+
+It polls each export to a deadline, downloads the result, and reads one athlete's CSV straight out of the session zip. The mutations, statuses, file layouts, and column schemas are documented under [Raw Data Export](https://playerdata.github.io/playerdatapy/raw-data-export/).
+
 ## Basic Usage Pattern
 
 ```python

--- a/examples/direct/queries/request_raw_data_export.graphql
+++ b/examples/direct/queries/request_raw_data_export.graphql
@@ -1,0 +1,9 @@
+mutation RequestRawDataExport($sessionParticipationId: ID!, $dataType: RawDataExportTypeEnum!, $format: RawDataExportFormatEnum!) {
+  requestRawDataExport(sessionParticipationId: $sessionParticipationId, dataType: $dataType, format: $format) {
+    status
+    downloadUrl
+    errors {
+      fullMessages
+    }
+  }
+}

--- a/examples/direct/queries/request_session_raw_data_export.graphql
+++ b/examples/direct/queries/request_session_raw_data_export.graphql
@@ -1,0 +1,10 @@
+mutation RequestSessionRawDataExport($sessionId: ID!, $dataType: RawDataExportTypeEnum!, $format: RawDataExportFormatEnum!) {
+  requestSessionRawDataExport(sessionId: $sessionId, dataType: $dataType, format: $format) {
+    status
+    downloadUrl
+    unavailableParticipationIds
+    errors {
+      fullMessages
+    }
+  }
+}

--- a/examples/direct/raw_data_export.py
+++ b/examples/direct/raw_data_export.py
@@ -1,0 +1,277 @@
+"""
+Export raw session data via the requestRawDataExport and requestSessionRawDataExport
+mutations. Picks the most recent session for a club, exports one athlete's data and the
+whole session, then reads a single athlete's CSV out of the session zip.
+
+Set CLIENT_ID, CLIENT_SECRET and CLUB_ID before running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import zipfile
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import polars as pl
+
+from playerdatapy.constants import GRAPHQL_URL
+from playerdatapy.gqlauth import AuthenticationType, GraphqlAuth
+from playerdatapy.gqlclient import Client
+
+CLIENT_ID = os.environ.get("CLIENT_ID")
+CLIENT_SECRET = os.environ.get("CLIENT_SECRET")
+CLUB_ID = os.environ.get("CLUB_ID")
+
+DATA_TYPE = "GPS"
+FORMAT = "CSV"
+POLL_INTERVAL = 15.0
+
+SESSIONS_QUERY = """
+query($clubIdEq: ID!, $startTimeGteq: ISO8601DateTime, $endTimeLteq: ISO8601DateTime) {
+  sessions(filter: {clubIdEq: $clubIdEq, startTimeGteq: $startTimeGteq, endTimeLteq: $endTimeLteq}) {
+    id
+    startTime
+    sessionParticipations {
+      id
+      athlete { name }
+    }
+  }
+}
+"""
+
+REQUEST_RAW_DATA_EXPORT = """
+mutation($id: ID!, $dataType: RawDataExportTypeEnum!, $format: RawDataExportFormatEnum!) {
+  requestRawDataExport(sessionParticipationId: $id, dataType: $dataType, format: $format) {
+    status
+    downloadUrl
+    errors { fullMessages }
+  }
+}
+"""
+
+REQUEST_SESSION_RAW_DATA_EXPORT = """
+mutation($id: ID!, $dataType: RawDataExportTypeEnum!, $format: RawDataExportFormatEnum!) {
+  requestSessionRawDataExport(sessionId: $id, dataType: $dataType, format: $format) {
+    status
+    downloadUrl
+    unavailableParticipationIds
+    errors { fullMessages }
+  }
+}
+"""
+
+
+def _raise_on_errors(result: dict) -> None:
+    if result["errors"]:
+        messages = [m for e in result["errors"] for m in e["fullMessages"]]
+        raise RuntimeError(f"Export failed: {messages}")
+
+
+async def request_raw_data(
+    client: Client,
+    session_participation_id: str,
+    data_type: str = DATA_TYPE,
+    format: str = FORMAT,
+    poll_interval: float = POLL_INTERVAL,
+    timeout: float = 900.0,
+) -> str:
+    """Request one participation's raw data export and poll until it is ready.
+
+    A participation with no data can report PROCESSING for up to 24 hours before it
+    latches to UNAVAILABLE, so polling is always bounded by `timeout`.
+
+    Args:
+        client: An authenticated GraphQL client.
+        session_participation_id: The session participation to export.
+        data_type: GPS, LPS, UWB, IMU, IMU_ACCELERATION, HEARTRATE, or FULL.
+        format: CSV or JSON.
+        poll_interval: Seconds to wait between polls.
+        timeout: Seconds to keep polling before giving up.
+
+    Returns:
+        A time-limited download URL for the export file.
+
+    Raises:
+        RuntimeError: The mutation returned validation errors, or the data is
+            unavailable for this participation.
+        TimeoutError: The export was still preparing when the deadline passed.
+    """
+    variables = {
+        "id": session_participation_id,
+        "dataType": data_type,
+        "format": format,
+    }
+    deadline = time.monotonic() + timeout
+
+    while True:
+        response = await client.execute(
+            query=REQUEST_RAW_DATA_EXPORT, variables=variables
+        )
+        result = client.get_data(response)["requestRawDataExport"]
+        _raise_on_errors(result)
+
+        if result["status"] == "READY":
+            return result["downloadUrl"]
+        if result["status"] == "UNAVAILABLE":
+            raise RuntimeError(
+                f"No {data_type} data for participation {session_participation_id}"
+            )
+        if time.monotonic() + poll_interval > deadline:
+            raise TimeoutError(f"Export still preparing after {timeout:.0f}s")
+
+        print(f"  preparing, polling again in {poll_interval:.0f}s")
+        await asyncio.sleep(poll_interval)
+
+
+async def request_session_raw_data(
+    client: Client,
+    session_id: str,
+    data_type: str = DATA_TYPE,
+    format: str = FORMAT,
+    poll_interval: float = POLL_INTERVAL,
+    timeout: float = 1800.0,
+) -> tuple[str, list[str]]:
+    """Request a whole session's raw data export and poll until it is ready.
+
+    Expect at least two calls: the call that finds every athlete's data ready is the
+    one that starts building the zip, so it returns PROCESSING.
+
+    Args:
+        client: An authenticated GraphQL client.
+        session_id: The session to export.
+        data_type: GPS, LPS, UWB, IMU, IMU_ACCELERATION, HEARTRATE, or FULL.
+        format: CSV or JSON. A session export is a zip either way.
+        poll_interval: Seconds to wait between polls.
+        timeout: Seconds to keep polling before giving up.
+
+    Returns:
+        A time-limited download URL for the zip, and the participation IDs left
+        out of it.
+
+    Raises:
+        RuntimeError: The mutation returned validation errors, or no athlete in
+            the session recorded this data type.
+        TimeoutError: The export was still preparing when the deadline passed.
+    """
+    variables = {"id": session_id, "dataType": data_type, "format": format}
+    deadline = time.monotonic() + timeout
+
+    while True:
+        response = await client.execute(
+            query=REQUEST_SESSION_RAW_DATA_EXPORT, variables=variables
+        )
+        result = client.get_data(response)["requestSessionRawDataExport"]
+        _raise_on_errors(result)
+
+        if result["status"] == "READY":
+            return result["downloadUrl"], result["unavailableParticipationIds"]
+        if result["status"] == "UNAVAILABLE":
+            raise RuntimeError(f"No {data_type} data for session {session_id}")
+        if time.monotonic() + poll_interval > deadline:
+            raise TimeoutError(f"Export still preparing after {timeout:.0f}s")
+
+        print(f"  preparing, polling again in {poll_interval:.0f}s")
+        await asyncio.sleep(poll_interval)
+
+
+async def download(url: str, path: str) -> None:
+    """Download an export to a local file.
+
+    Args:
+        url: The download URL returned by an export mutation. Links expire 15
+            minutes after they are issued.
+        path: Where to write the file.
+    """
+    async with httpx.AsyncClient(timeout=60.0) as http_client:
+        response = await http_client.get(url)
+        response.raise_for_status()
+        with open(path, "wb") as file:
+            file.write(response.content)
+
+
+def athlete_frame(zip_path: str, participation_id: str) -> pl.DataFrame:
+    """Read one athlete's GPS CSV out of a session zip without extracting it.
+
+    Args:
+        zip_path: Path to a downloaded session export.
+        participation_id: The session participation whose folder to read.
+
+    Returns:
+        The athlete's GPS samples.
+    """
+    with zipfile.ZipFile(zip_path) as archive:
+        with archive.open(f"{participation_id}/gps.csv") as csv_file:
+            return pl.read_csv(csv_file)
+
+
+async def latest_session(client: Client) -> dict | None:
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=30)
+    response = await client.execute(
+        query=SESSIONS_QUERY,
+        variables={
+            "clubIdEq": CLUB_ID,
+            "startTimeGteq": start.isoformat(),
+            "endTimeLteq": end.isoformat(),
+        },
+    )
+    sessions = client.get_data(response)["sessions"]
+    if not sessions:
+        return None
+    return max(sessions, key=lambda s: s["startTime"])
+
+
+async def main() -> None:
+    auth = GraphqlAuth(
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        type=AuthenticationType.CLIENT_CREDENTIALS_FLOW,
+    )
+    client = Client(
+        url=GRAPHQL_URL,
+        headers={
+            "Authorization": f"Bearer {auth.authenticated_session.token['access_token']}"
+        },
+    )
+
+    session = await latest_session(client)
+    if not session:
+        print("No sessions in the last 30 days.")
+        return
+
+    participations = session["sessionParticipations"]
+    if not participations:
+        print(f"Session {session['id']} has no participations.")
+        return
+
+    participation = participations[0]
+    print(f"Session {session['id']} ({session['startTime']})")
+    print(f"Exporting {DATA_TYPE} for {participation['athlete']['name']}")
+    url = await request_raw_data(client, participation["id"])
+    await download(url, "gps.csv")
+    print("saved gps.csv")
+
+    print(f"Exporting {DATA_TYPE} for the whole session")
+    zip_url, unavailable = await request_session_raw_data(client, session["id"])
+    await download(zip_url, "session_gps.zip")
+    print("saved session_gps.zip")
+
+    if unavailable:
+        print(
+            f"{len(unavailable)} athlete(s) had no {DATA_TYPE} data and were left out"
+        )
+
+    with zipfile.ZipFile("session_gps.zip") as archive:
+        for name in archive.namelist():
+            print(f"  {name}")
+
+    if participation["id"] not in unavailable:
+        frame = athlete_frame("session_gps.zip", participation["id"])
+        print(frame.head())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Authentication: auth.md
       - Concepts: concepts.md
       - Metrics: metrics.md
+      - Raw Data Export: raw-data-export.md
       - Pagination & Limits: limits.md
       - Errors: errors.md
       - Clients: clients.md


### PR DESCRIPTION
## Motivation

Two raw-data-export mutations are now live in the API and were previously undocumented here:

- `requestRawDataExport` — one athlete's data in one session (a session participation).
- `requestSessionRawDataExport` — a whole session in one zip, one folder per athlete.

Source: [Exporting Raw Data via the PlayerData API](https://www.notion.so/playerdata/Exporting-Raw-Data-via-the-PlayerData-API-3aa73a7e2df181fe9e6ec337da42199d) (canonical customer doc).

## Overview

- `docs/raw-data-export.md` — new API guide: both mutations with argument and return tables, the three `RawDataStatusEnum` states, export lifecycle (15 minute links, ~45 minute reuse window, UTC timestamps), output layouts for participation and session scope, and the column schema for `GPS`, `LPS`/`UWB`, `IMU`, `IMU_ACCELERATION` and `HEARTRATE`.
- `examples/direct/raw_data_export.py` — runnable example following the `examples/direct/` idiom. Polls both mutations with a `poll_interval` and a `timeout`, downloads the results, and reads one athlete's CSV straight out of the session zip with `zipfile` + `polars`.
- `examples/direct/queries/request_raw_data_export.graphql`, `request_session_raw_data_export.graphql` — the two mutation documents alongside the existing query files.
- Nav entry in `mkdocs.yml` plus cross-links from `docs/index.md`, `docs/api/overview.md`, `docs/metrics.md`, `docs/examples.md`, `README.md` and `examples/direct/README.md`.

Docs only — no generated bindings touched and `schema.graphql` is untouched (codegen regenerates it separately). Example verified with the repo's pinned `ruff check` and `ruff format`; nothing was executed against the live API.

## Before merging

`requestSessionRawDataExport` is not currently working in production. Black-box testing showed the participation-scoped mutation reaching `READY` and downloading correctly, while the session-scoped mutation returned `PROCESSING` → `PROCESSING` → `UNAVAILABLE` with an empty `unavailableParticipationIds`, i.e. the zip build job fails.

The session-scope half of this guide therefore describes intended behaviour that does not yet work in production. This PR should stay in draft until that is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
